### PR TITLE
feat: add url command

### DIFF
--- a/src/commands/clear-cache.ts
+++ b/src/commands/clear-cache.ts
@@ -1,0 +1,8 @@
+import { HttpClient } from "../http/client.js";
+import chalk from "chalk";
+
+export const handleClearCache = (): void => {
+  const client = new HttpClient();
+  client.clearCache();
+  console.log(chalk.green("Cache cleared successfully"));
+};

--- a/src/commands/url.ts
+++ b/src/commands/url.ts
@@ -1,13 +1,14 @@
 import { HttpClient } from "../http/client.js";
 import { convert } from "html-to-text";
 import chalk from "chalk";
+import config from "../config.js";
 
 export const handleUrl = async (url: string): Promise<void> => {
   console.log(chalk.blue(`Fetching ${url}...`));
 
   const client = new HttpClient();
   const response = await client.request(url, {
-    preferredFormat: "html",
+    preferredFormat: config.http.defaultPreferredFormat,
   });
 
   if (response.statusCode !== 200) {
@@ -38,7 +39,7 @@ const displayJson = (body: string): void => {
 
 const displayHtml = (body: string): void => {
   const text = convert(body, {
-    wordwrap: 130,
+    wordwrap: config.display.wordWrap,
     selectors: [
       { selector: "img", format: "skip" },
       { selector: "script", format: "skip" },

--- a/src/commands/url.ts
+++ b/src/commands/url.ts
@@ -2,28 +2,30 @@ import { HttpClient } from "../http/client.js";
 import { convert } from "html-to-text";
 import chalk from "chalk";
 
-export async function handleUrl(url: string): Promise<void> {
+export const handleUrl = async (url: string): Promise<void> => {
   console.log(chalk.blue(`Fetching ${url}...`));
 
   const client = new HttpClient();
-  const response = await client.request(url);
+  const response = await client.request(url, {
+    preferredFormat: "html",
+  });
 
   if (response.statusCode !== 200) {
     throw new Error(`Request failed with status code ${response.statusCode}`);
   }
 
-  const contentType = response.headers["content-type"] || "";
+  const [mediaType] = (response.headers["content-type"] || "").split(";");
 
-  if (contentType.includes("application/json")) {
+  if (mediaType.includes("application/json")) {
     displayJson(response.body);
-  } else if (contentType.includes("text/html")) {
+  } else if (mediaType.includes("text/html")) {
     displayHtml(response.body);
   } else {
     console.log(response.body);
   }
-}
+};
 
-function displayJson(body: string): void {
+const displayJson = (body: string): void => {
   try {
     const parsed = JSON.parse(body);
     console.log(chalk.cyan("JSON Response:"));
@@ -32,9 +34,9 @@ function displayJson(body: string): void {
     console.log(chalk.red("Failed to parse JSON response"));
     console.log(body);
   }
-}
+};
 
-function displayHtml(body: string): void {
+const displayHtml = (body: string): void => {
   const text = convert(body, {
     wordwrap: 130,
     selectors: [
@@ -59,4 +61,4 @@ function displayHtml(body: string): void {
 
   console.log(chalk.cyan("HTML Response:"));
   console.log(text);
-}
+};

--- a/src/commands/url.ts
+++ b/src/commands/url.ts
@@ -1,0 +1,62 @@
+import { HttpClient } from "../http/client.js";
+import { convert } from "html-to-text";
+import chalk from "chalk";
+
+export async function handleUrl(url: string): Promise<void> {
+  console.log(chalk.blue(`Fetching ${url}...`));
+
+  const client = new HttpClient();
+  const response = await client.request(url);
+
+  if (response.statusCode !== 200) {
+    throw new Error(`Request failed with status code ${response.statusCode}`);
+  }
+
+  const contentType = response.headers["content-type"] || "";
+
+  if (contentType.includes("application/json")) {
+    displayJson(response.body);
+  } else if (contentType.includes("text/html")) {
+    displayHtml(response.body);
+  } else {
+    console.log(response.body);
+  }
+}
+
+function displayJson(body: string): void {
+  try {
+    const parsed = JSON.parse(body);
+    console.log(chalk.cyan("JSON Response:"));
+    console.log(chalk.yellow(JSON.stringify(parsed, null, 2)));
+  } catch (error) {
+    console.log(chalk.red("Failed to parse JSON response"));
+    console.log(body);
+  }
+}
+
+function displayHtml(body: string): void {
+  const text = convert(body, {
+    wordwrap: 130,
+    selectors: [
+      { selector: "img", format: "skip" },
+      { selector: "script", format: "skip" },
+      { selector: "style", format: "skip" },
+      { selector: "a", options: { hideLinkHrefIfSameAsText: true } },
+      { selector: "h1", format: "heading" },
+      { selector: "h2", format: "heading" },
+      { selector: "h3", format: "heading" },
+      { selector: "ul", format: "unorderedList" },
+      { selector: "ol", format: "orderedList" },
+    ],
+    formatters: {
+      heading: (elem, walk, builder, formatOptions) => {
+        builder.openBlock();
+        builder.addInline(chalk.bold.cyan(elem.children[0].data));
+        builder.closeBlock();
+      },
+    },
+  });
+
+  console.log(chalk.cyan("HTML Response:"));
+  console.log(text);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,4 +15,9 @@ export default {
     engine: "duckduckgo",
     resultsPerPage: 10,
   },
+  cache: {
+    enabled: true,
+    maxAge: 60000, // 1 minute
+    maxSize: 50, // number of cached responses
+  },
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,18 @@
+import { ContentFormat } from "./types/http";
+
+export default {
+  http: {
+    maxRedirects: 5,
+    defaultPreferredFormat: "html" as ContentFormat,
+    userAgent:
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+  },
+  display: {
+    wordWrap: 130,
+    colorEnabled: true,
+  },
+  search: {
+    engine: "duckduckgo",
+    resultsPerPage: 10,
+  },
+};

--- a/src/http/client.ts
+++ b/src/http/client.ts
@@ -6,14 +6,20 @@ import { HttpResponse, HttpRequestOptions } from "../types/http.js";
 export class HttpClient {
   private buildHeaders(
     hostname: string,
-    customHeaders: Record<string, string> = {}
+    customHeaders: Record<string, string> = {},
+    preferredFormat?: "html" | "json"
   ): Record<string, string> {
+    const accept =
+      preferredFormat === "json"
+        ? "application/json;q=1.0, text/html;q=0.8"
+        : "text/html;q=1.0, application/json;q=0.8";
+
     return {
       Host: hostname,
       Connection: "close",
-      Accept: "text/html,application/json",
+      Accept: accept,
       "User-Agent":
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
       ...customHeaders,
     };
   }
@@ -24,6 +30,11 @@ export class HttpClient {
     search: string,
     headers: Record<string, string>
   ): string[] {
+    // example:
+    // GET / HTTP/1.1
+    // Host: example.com
+    // User-Agent: curl/8.0.1
+    // Accept: */*
     return [
       `${method} ${path || "/"}${search || ""} HTTP/1.1`,
       ...Object.entries(headers).map(([key, value]) => `${key}: ${value}`),
@@ -56,7 +67,11 @@ export class HttpClient {
           });
 
       const sendRequest = () => {
-        const headers = this.buildHeaders(url.hostname, options.headers);
+        const headers = this.buildHeaders(
+          url.hostname,
+          options.headers,
+          options.preferredFormat
+        );
         const requestLines = this.buildRequestLines(
           options.method || "GET",
           url.pathname,

--- a/src/http/client.ts
+++ b/src/http/client.ts
@@ -1,0 +1,120 @@
+import * as net from "net";
+import * as tls from "tls";
+import { URL } from "url";
+import { HttpResponse, HttpRequestOptions } from "../types/http.js";
+
+export class HttpClient {
+  private buildHeaders(
+    hostname: string,
+    customHeaders: Record<string, string> = {}
+  ): Record<string, string> {
+    return {
+      Host: hostname,
+      Connection: "close",
+      Accept: "text/html,application/json",
+      "User-Agent":
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+      ...customHeaders,
+    };
+  }
+
+  private buildRequestLines(
+    method: string,
+    path: string,
+    search: string,
+    headers: Record<string, string>
+  ): string[] {
+    return [
+      `${method} ${path || "/"}${search || ""} HTTP/1.1`,
+      ...Object.entries(headers).map(([key, value]) => `${key}: ${value}`),
+      "",
+      "",
+    ];
+  }
+
+  async request(
+    urlString: string,
+    options: HttpRequestOptions = {}
+  ): Promise<HttpResponse> {
+    const url = new URL(urlString);
+    const isHttps = url.protocol === "https:";
+    const port = Number(url.port) || (isHttps ? 443 : 80);
+
+    return new Promise((resolve, reject) => {
+      const connectOptions = {
+        host: url.hostname,
+        port: port,
+        servername: url.hostname,
+      } as tls.ConnectionOptions;
+
+      const socket = isHttps
+        ? tls.connect(connectOptions, () => {
+            sendRequest();
+          })
+        : net.connect(port, url.hostname, () => {
+            sendRequest();
+          });
+
+      const sendRequest = () => {
+        const headers = this.buildHeaders(url.hostname, options.headers);
+        const requestLines = this.buildRequestLines(
+          options.method || "GET",
+          url.pathname,
+          url.search,
+          headers
+        );
+        socket.write(requestLines.join("\r\n"));
+      };
+
+      let rawResponse = "";
+      socket.on("data", (chunk) => {
+        rawResponse += chunk;
+      });
+
+      socket.on("end", () => {
+        try {
+          const response = this.parseResponse(rawResponse);
+          const REDIRECT_CODES = [301, 302, 307, 308];
+
+          if (
+            REDIRECT_CODES.includes(response.statusCode) &&
+            response.headers.location
+          ) {
+            this.request(response.headers.location, options)
+              .then(resolve)
+              .catch(reject);
+          } else {
+            resolve(response);
+          }
+        } catch (error) {
+          reject(error);
+        }
+      });
+
+      socket.on("error", (error) => {
+        reject(error);
+      });
+    });
+  }
+
+  private parseResponse(rawResponse: string): HttpResponse {
+    const [headerSection, ...bodyParts] = rawResponse.split("\r\n\r\n");
+    const body = bodyParts.join("\r\n\r\n");
+    const [statusLine, ...headerLines] = headerSection.split("\r\n");
+    const [, statusCode] = statusLine.match(/HTTP\/\d\.\d (\d{3})/) || [];
+
+    const headers: Record<string, string> = {};
+    for (const line of headerLines) {
+      const [key, ...values] = line.split(":");
+      if (key) {
+        headers[key.trim().toLowerCase()] = values.join(":").trim();
+      }
+    }
+
+    return {
+      statusCode: parseInt(statusCode, 10),
+      headers,
+      body,
+    };
+  }
+}

--- a/src/http/client.ts
+++ b/src/http/client.ts
@@ -1,13 +1,18 @@
 import * as net from "net";
 import * as tls from "tls";
 import { URL } from "url";
-import { HttpResponse, HttpRequestOptions } from "../types/http.js";
+import {
+  HttpResponse,
+  HttpRequestOptions,
+  ContentFormat,
+} from "../types/http.js";
+import config from "../config.js";
 
 export class HttpClient {
   private buildHeaders(
     hostname: string,
     customHeaders: Record<string, string> = {},
-    preferredFormat?: "html" | "json"
+    preferredFormat?: ContentFormat
   ): Record<string, string> {
     const accept =
       preferredFormat === "json"
@@ -18,8 +23,7 @@ export class HttpClient {
       Host: hostname,
       Connection: "close",
       Accept: accept,
-      "User-Agent":
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+      "User-Agent": config.http.userAgent,
       ...customHeaders,
     };
   }
@@ -48,10 +52,9 @@ export class HttpClient {
     options: HttpRequestOptions = {},
     redirectCount = 0
   ): Promise<HttpResponse> {
-    const MAX_REDIRECTS = 5;
-    if (redirectCount >= MAX_REDIRECTS) {
+    if (redirectCount >= config.http.maxRedirects) {
       throw new Error(
-        `Maximum number of redirects (${MAX_REDIRECTS}) exceeded`
+        `Maximum number of redirects (${config.http.maxRedirects}) exceeded`
       );
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 // the above line is used to run the script as a node script
 
-import { Command } from "commander";
 import chalk from "chalk";
+import { Command } from "commander";
+import { handleUrl } from "./commands/url.js";
 
 const program = new Command();
 
@@ -24,7 +25,7 @@ async function main() {
   try {
     // TODO: implement the commands
     if (options.url) {
-      console.log(chalk.green("URL option selected"));
+      await handleUrl(options.url);
     } else if (options.search) {
       console.log(chalk.green("Search option selected"));
     } else {
@@ -34,7 +35,7 @@ async function main() {
   } catch (error) {
     console.error(
       chalk.red("Error:"),
-      error instanceof Error ? error.message : "An unknown error occurred"
+      error instanceof Error ? error.message : "An error occurred"
     );
     process.exit(1);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@
 import chalk from "chalk";
 import { Command } from "commander";
 import { handleUrl } from "./commands/url.js";
+import { handleClearCache } from "./commands/clear-cache.js";
 
 const program = new Command();
 
@@ -15,6 +16,7 @@ program
 program
   .option("-u, --url <url>", "make an HTTP request to the given URL")
   .option("-s, --search <term>", "search term using DuckDuckGo")
+  .option("-c, --clear-cache", "clear the HTTP cache")
   .option("-h, --help", "show help information");
 
 program.parse(process.argv);
@@ -23,15 +25,33 @@ const options = program.opts();
 
 async function main() {
   try {
-    // TODO: implement the commands
+    if (options.clearCache) {
+      handleClearCache();
+      return;
+    }
+
     if (options.url) {
       await handleUrl(options.url);
-    } else if (options.search) {
-      console.log(chalk.green("Search option selected"));
-    } else {
-      // builtin help command
-      program.help();
+      return;
     }
+
+    if (options.search) {
+      // TODO: implement search
+      return;
+    }
+
+    program.help();
+
+    // if (options.clearCache) {
+    //   handleClearCache();
+    // } else if (options.url) {
+    //   await handleUrl(options.url);
+    // } else if (options.search) {
+    //   // TODO: implement search
+    //   console.log(chalk.green("Search option selected"));
+    // } else {
+    //   program.help();
+    // }
   } catch (error) {
     console.error(
       chalk.red("Error:"),

--- a/src/services/cache.ts
+++ b/src/services/cache.ts
@@ -1,0 +1,118 @@
+import { HttpResponse } from "../types/http.js";
+import config from "../config.js";
+import chalk from "chalk";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+type CacheEntry = {
+  response: HttpResponse;
+  timestamp: number;
+};
+
+export class CacheService {
+  private static instance: CacheService;
+  private cache: Map<string, CacheEntry>;
+  private cacheDir: string;
+  private cacheFile: string;
+
+  constructor() {
+    this.cache = new Map();
+    this.cacheDir = path.join(os.homedir(), ".go2web");
+    this.cacheFile = path.join(this.cacheDir, "cache.json");
+    this.initCache();
+  }
+
+  static getInstance(): CacheService {
+    if (!CacheService.instance) {
+      CacheService.instance = new CacheService();
+    }
+    return CacheService.instance;
+  }
+
+  private initCache(): void {
+    try {
+      if (!fs.existsSync(this.cacheDir)) {
+        fs.mkdirSync(this.cacheDir, { recursive: true });
+      }
+
+      if (fs.existsSync(this.cacheFile)) {
+        const data = fs.readFileSync(this.cacheFile, "utf-8");
+        const entries = JSON.parse(data);
+
+        for (const [key, value] of Object.entries(entries)) {
+          this.cache.set(key, value as CacheEntry);
+        }
+      }
+    } catch (error) {
+      console.error("Failed to initialize cache:", error);
+    }
+  }
+
+  private saveCache(): void {
+    try {
+      const entries = Object.fromEntries(this.cache.entries());
+      fs.writeFileSync(this.cacheFile, JSON.stringify(entries, null, 2));
+    } catch (error) {
+      console.error("Failed to save cache:", error);
+    }
+  }
+
+  get(url: string): HttpResponse | null {
+    if (!config.cache.enabled) return null;
+
+    const entry = this.cache.get(url);
+    if (!entry) {
+      return null;
+    }
+
+    // if cache is still valid
+    const now = Date.now();
+    if (now - entry.timestamp > config.cache.maxAge) {
+      this.cache.delete(url);
+      this.saveCache();
+      return null;
+    }
+
+    return entry.response;
+  }
+
+  set(url: string, response: HttpResponse): void {
+    if (!config.cache.enabled) return;
+
+    // error responses
+    if (response.statusCode >= 400) {
+      return;
+    }
+
+    if (this.cache.size >= config.cache.maxSize) {
+      const oldestKey = this.findOldestEntry();
+      if (oldestKey) {
+        this.cache.delete(oldestKey);
+      }
+    }
+
+    this.cache.set(url, {
+      response,
+      timestamp: Date.now(),
+    });
+
+    this.saveCache();
+  }
+
+  clear(): void {
+    this.cache.clear();
+    this.saveCache();
+  }
+
+  private findOldestEntry(): string | null {
+    const oldestTime = Math.min(
+      ...Object.values(this.cache).map((entry) => entry.timestamp)
+    );
+    const oldestKey = Object.keys(this.cache).find(
+      (key: string) => this.cache.get(key)?.timestamp === oldestTime
+    );
+
+    return oldestKey ?? null;
+  }
+}

--- a/src/services/cache.ts
+++ b/src/services/cache.ts
@@ -85,6 +85,11 @@ export class CacheService {
       return;
     }
 
+    const cacheControl = response.headers["cache-control"] || "";
+    if (cacheControl.includes("no-store")) {
+      return;
+    }
+
     if (this.cache.size >= config.cache.maxSize) {
       const oldestKey = this.findOldestEntry();
       if (oldestKey) {

--- a/src/types/http.ts
+++ b/src/types/http.ts
@@ -8,4 +8,5 @@ export interface HttpRequestOptions {
   method?: "GET" | "POST";
   headers?: Record<string, string>;
   path?: string;
+  preferredFormat?: "html" | "json";
 }

--- a/src/types/http.ts
+++ b/src/types/http.ts
@@ -1,0 +1,11 @@
+export interface HttpResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+export interface HttpRequestOptions {
+  method?: "GET" | "POST";
+  headers?: Record<string, string>;
+  path?: string;
+}

--- a/src/types/http.ts
+++ b/src/types/http.ts
@@ -8,5 +8,7 @@ export interface HttpRequestOptions {
   method?: "GET" | "POST";
   headers?: Record<string, string>;
   path?: string;
-  preferredFormat?: "html" | "json";
+  preferredFormat?: ContentFormat;
 }
+
+export type ContentFormat = "html" | "json";


### PR DESCRIPTION
- Add support for the `-u` command with a class for the HTTP client using `net` and `tls`
- Handle redirects (with configurable limit)
- Implement content negotiation using the `Accept` header
- Use file-based caching mechanism + add the `-c` command for clearing cache